### PR TITLE
Step8 ver1 : Build Docker image using CI 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,10 @@ jobs:
         echo 'Tag: ${{ steps.meta.outputs.tags }}'
         echo 'Label: ${{ steps.meta.labels.tags }}'
 
-    # - name: Build and push Docker image
-    #   uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-    #   with:
-    #     context: <go or python>
-    #     push: true
-    #     tags: ${{ steps.meta.outputs.tags }}
-    #     labels: ${{ steps.meta.outputs.labels }}
+    - name: Build and push Docker image
+      uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      with:
+        context: ./go
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The following icons indicate pointers for
   /[EN](document/04-api.en.md))
 - [x] **STEP5** Database ([JA](document/05-database.ja.md)/[EN](document/05-database.en.md))
 - [ ] **STEP6** Writing Tests ([JA](document/06-testing.ja.md)/[EN](document/06-testing.en.md))
-- [ ] **STEP7** Docker ([JA](document/07-docker.ja.md)/[EN](document/07-docker.en.md))
+- [x] **STEP7** Docker ([JA](document/07-docker.ja.md)/[EN](document/07-docker.en.md))
 - [ ] **STEP8** Continuous Integration(CI) ([JA](document/08-ci.ja.md)
   /[EN](document/08-ci.en.md))
 - [ ] **STEP9** (Stretch) Frontend ([JA](document/09-frontend.ja.md)

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -18,7 +18,7 @@ COPY . .
 
 # ユーザー・グループの作成と権限設定
 RUN addgroup -S mercari && adduser -S trainee -G mercari \
-    && chown -R trainee:mercari db 
+    && chown -R trainee:mercari db images
 
 # バイナリをビルド
 RUN go build -o server cmd/api/main.go


### PR DESCRIPTION
ローカルでstep8をプッシュしたら何故かremoteのmainにマージされてしまったため、新しくブランチを作成しました。
mainもapproveもらったブランチの変更だけマージされている状態に修復しました。

I pushed step8 locally, which somehow got merged into the remote main.
To fix this, I created a new branch and restored main to include only the approved changes.

## What
**以下のファイルを修正しました**
- build.yml 
- Dockerfile (imagesディレクトリの権限の追加)
- server.go (sqlite3のファイルがない場合作成するように変更)
- infra.go (sqlite3のファイルがない場合作成するように変更)

## What
**Modified the following files:**
- build.yml
- Dockerfile (Added permission settings for the images directory)
- server.go (Now creates an sqlite3 file if it doesn’t exist)
- infra.go (Now creates an sqlite3 file if it doesn’t exist)


## Execution Result
```
$ docker pull ghcr.io/niwatorinoko/mercari-build-training:step8
step8: Pulling from niwatorinoko/mercari-build-training
0a9a5dfd008f: Already exists 
d5d2700a21cf: Already exists 
a2a60326dddc: Already exists 
3fc85565184c: Already exists 
4f4fb700ef54: Already exists 
44f9e7f9aee6: Pull complete 
b913c21f0111: Pull complete 
073267689749: Pull complete 
66a4057a65b2: Pull complete 
f4aea7708796: Pull complete 
04f07822f0e3: Pull complete 
f899ae53497e: Pull complete 
Digest: sha256:cadf5babe7ebb5215d965ef7174c46eea5de9907d52c538f74b36096f263b489
Status: Downloaded newer image for ghcr.io/niwatorinoko/mercari-build-training:step8
ghcr.io/niwatorinoko/mercari-build-training:step8
```
```
$ docker run --rm -p 9000:9000 ghcr.io/niwatorinoko/mercari-build-training:step8
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
{"time":"2025-03-11T02:46:59.14598043Z","level":"INFO","msg":"http server started on","port":"9000"}
{"time":"2025-03-11T02:47:07.78525617Z","level":"INFO","msg":"request received","method":"GET","path":"/items","remote_addr":"192.168.65.1:59285","user_agent":"curl/8.7.1"}
{"time":"2025-03-11T02:47:22.310191718Z","level":"INFO","msg":"request received","method":"POST","path":"/items","remote_addr":"192.168.65.1:49820","user_agent":"curl/8.7.1"}
{"time":"2025-03-11T02:47:22.327088885Z","level":"INFO","msg":"item received: iPhone16"}
{"time":"2025-03-11T02:47:26.555483262Z","level":"INFO","msg":"request received","method":"GET","path":"/items","remote_addr":"192.168.65.1:23274","user_agent":"curl/8.7.1"}
```
```
$ curl -X POST \
  --url 'http://localhost:9000/items' \
  -F 'name=iPhone16' \
  -F 'category=phone' \
  -F 'image=@images/default.jpg'
{"message":"item received: iPhone16"}
```
```
$ curl -X GET 'http://127.0.0.1:9000/items'          
{"items":[{"name":"tie","category_id":1,"category_name":"fashion","image_name":"ad55d25f2c10c56522147b214aeed7ad13319808d7ce999787ac8c239b24f71d.jpg"},{"name":"iPhone16","category_id":2,"category_name":"phone","image_name":"ad55d25f2c10c56522147b214aeed7ad13319808d7ce999787ac8c239b24f71d.jpg"},{"name":"iPhone16","category_id":2,"category_name":"phone","image_name":"ad55d25f2c10c56522147b214aeed7ad13319808d7ce999787ac8c239b24f71d.jpg"},{"name":"iPhone16","category_id":2,"category_name":"phone","image_name":"ad55d25f2c10c56522147b214aeed7ad13319808d7ce999787ac8c239b24f71d.jpg"}]}
```
```
$ curl -X GET 'http://127.0.0.1:9000/items/4'
{"name":"iPhone16","category_id":2,"category_name":"phone","image_name":"ad55d25f2c10c56522147b214aeed7ad13319808d7ce999787ac8c239b24f71d.jpg"}
```
```
$ curl -X GET 'http://127.0.0.1:9000/search?keyword=phone'          
{"items":[{"name":"iPhone16","category_id":2,"category_name":"phone","image_name":"ad55d25f2c10c56522147b214aeed7ad13319808d7ce999787ac8c239b24f71d.jpg"},{"name":"iPhone16","category_id":2,"category_name":"phone","image_name":"ad55d25f2c10c56522147b214aeed7ad13319808d7ce999787ac8c239b24f71d.jpg"},{"name":"iPhone16","category_id":2,"category_name":"phone","image_name":"ad55d25f2c10c56522147b214aeed7ad13319808d7ce999787ac8c239b24f71d.jpg"}]}
```
